### PR TITLE
feat; reuse resolvers and validators

### DIFF
--- a/libs/margarita-form/src/lib/managers/margarita-form-params-manager.ts
+++ b/libs/margarita-form/src/lib/managers/margarita-form-params-manager.ts
@@ -15,10 +15,14 @@ class ParamsManager<CONTROL extends MFC> extends BaseManager {
     const paramsSubscriptionObservable = combineLatest([control.valueChanges, control.stateChanges]).pipe(
       debounceTime(1),
       switchMap(([value]) => {
-        return mapResolverEntries('Params', control.field.params, {
-          control,
-          value,
-          params: null,
+        return mapResolverEntries({
+          title: 'Params',
+          from: control.field.params,
+          context: {
+            control,
+            value,
+            params: null,
+          },
         });
       })
     );

--- a/libs/margarita-form/src/lib/managers/margarita-form-state-manager.ts
+++ b/libs/margarita-form/src/lib/managers/margarita-form-state-manager.ts
@@ -48,10 +48,14 @@ class StateManager<CONTROL extends MFC> extends BaseManager implements Margarita
           return acc;
         }, {} as CommonRecord);
 
-        return mapResolverEntries('State', state, {
-          control: this.control,
-          value,
-          params: null,
+        return mapResolverEntries({
+          title: 'State',
+          from: state,
+          context: {
+            control: this.control,
+            value,
+            params: null,
+          },
         });
       })
     );
@@ -64,10 +68,17 @@ class StateManager<CONTROL extends MFC> extends BaseManager implements Margarita
 
     const validationStateSubscriptionObservable = this.control.valueChanges.pipe(
       switchMap((value) => {
-        return mapResolverEntries<MargaritaFormValidatorResult>('State', this.control.field.validation, {
-          control: this.control,
-          value,
-          params: null,
+        const validators = this.control.validators;
+        return mapResolverEntries<MargaritaFormValidatorResult>({
+          title: 'State',
+          from: this.control.field.validation || {},
+          resolveStaticValues: false,
+          resolvers: validators,
+          context: {
+            control: this.control,
+            value,
+            params: null,
+          },
         });
       }),
       combineLatestWith(
@@ -83,6 +94,8 @@ class StateManager<CONTROL extends MFC> extends BaseManager implements Margarita
     );
 
     this.createSubscription(validationStateSubscriptionObservable, ([validationStates, children]) => {
+      // console.log('validationStates', validationStates);
+
       const childrenAreValid = children.every((child) => child.valid || child.inactive);
       const currentIsValid = Object.values(validationStates).every((state) => state.valid);
 

--- a/libs/margarita-form/src/lib/managers/ref-manager-helpers/margarita-form-ref-state-changes.ts
+++ b/libs/margarita-form/src/lib/managers/ref-manager-helpers/margarita-form-ref-state-changes.ts
@@ -72,10 +72,14 @@ export const handleControlAttributeChanges = <CONTROL extends MFC = MFC>({
     .pipe(
       debounceTime(1),
       switchMap(([value]) => {
-        return mapResolverEntries('Attributes', control.field.attributes, {
-          control,
-          value,
-          params: null,
+        return mapResolverEntries({
+          title: 'Attributes',
+          from: control.field.attributes,
+          context: {
+            control,
+            value,
+            params: null,
+          },
         });
       })
     )

--- a/libs/margarita-form/src/lib/margarita-form-types.ts
+++ b/libs/margarita-form/src/lib/margarita-form-types.ts
@@ -120,6 +120,7 @@ export interface MargaritaFormState extends UserDefinedStates<boolean> {
   submitResult: 'not-submitted' | 'form-invalid' | 'error' | 'success';
   errors: MargaritaFormStateErrors;
   children?: MargaritaFormStateChildren;
+  hasValue?: boolean;
 }
 
 export interface MargaritaFormConfig {

--- a/libs/margarita-form/src/lib/margarita-form-types.ts
+++ b/libs/margarita-form/src/lib/margarita-form-types.ts
@@ -17,6 +17,7 @@ export interface MargaritaFormFieldContext<CONTROL extends MargaritaFormControl 
   value: CONTROL['value'];
   params: PARAMS;
   control: CONTROL;
+  errorMessage?: string;
 }
 
 export type MargaritaFormResolverOutput<OUTPUT = unknown> = OUTPUT | Promise<OUTPUT> | Observable<OUTPUT>;

--- a/libs/margarita-form/src/lib/validators/color-validator.ts
+++ b/libs/margarita-form/src/lib/validators/color-validator.ts
@@ -1,8 +1,8 @@
 import { MargaritaFormValidator } from '../margarita-form-types';
 
 export const colorValidator: (errorMessage?: string) => MargaritaFormValidator<boolean> =
-  (errorMessage = 'Value must be a valid color code!') =>
-  ({ value, params }) => {
+  (defaultErrorMessage = 'Value must be a valid color code!') =>
+  ({ value, params, errorMessage = defaultErrorMessage }) => {
     if (!params || !value) return { valid: true };
     const regex = new RegExp(/#[0-9a-zA-Z]{3,8}|(rgba?|hsla?)\([^,]{1,4},[^,]{1,4},[^,]{1,4}(,[^,]{1,3})?\)/gi);
     const stringValue = typeof value === 'string' ? value : String(value);

--- a/libs/margarita-form/src/lib/validators/date-validator.ts
+++ b/libs/margarita-form/src/lib/validators/date-validator.ts
@@ -1,8 +1,8 @@
 import { MargaritaFormValidator } from '../margarita-form-types';
 
 export const dateValidator: (errorMessage?: string) => MargaritaFormValidator<boolean> =
-  (errorMessage = 'Please enter a valid date!') =>
-  ({ value, params }) => {
+  (defaultErrorMessage = 'Please enter a valid date!') =>
+  ({ value, params, errorMessage = defaultErrorMessage }) => {
     if (!params || !value) return { valid: true };
     const date = value instanceof Date ? value : new Date(String(value));
     const valid = Boolean(date.getTime());

--- a/libs/margarita-form/src/lib/validators/email-validator.ts
+++ b/libs/margarita-form/src/lib/validators/email-validator.ts
@@ -1,8 +1,8 @@
 import { MargaritaFormValidator } from '../margarita-form-types';
 
 export const emailValidator: (errorMessage?: string) => MargaritaFormValidator<boolean> =
-  (errorMessage = 'Value must be a valid email address!') =>
-  ({ value, params }) => {
+  (defaultErrorMessage = 'Value must be a valid email address!') =>
+  ({ value, params, errorMessage = defaultErrorMessage }) => {
     if (!params || !value) return { valid: true };
     const regex = new RegExp(/.+@.+\..+/g);
     const stringValue = typeof value === 'string' ? value : String(value);

--- a/libs/margarita-form/src/lib/validators/min-max-validators.ts
+++ b/libs/margarita-form/src/lib/validators/min-max-validators.ts
@@ -11,8 +11,8 @@ const compare = (value: unknown, comparisonFn: (value: number) => boolean) => {
 };
 
 export const minValidator: (errorMessage?: string) => MargaritaFormValidator<number> =
-  (errorMessage = 'Value is too low!') =>
-  ({ value, params: minValue }) => {
+  (defaultErrorMessage = 'Value is too low!') =>
+  ({ value, params: minValue, errorMessage = defaultErrorMessage }) => {
     if (invalids.includes(minValue)) return { valid: true };
     if (invalids.includes(value)) return { valid: true };
     const valueIsInvalid = compare(value, (number) => number < minValue);
@@ -21,8 +21,8 @@ export const minValidator: (errorMessage?: string) => MargaritaFormValidator<num
   };
 
 export const maxValidator: (errorMessage?: string) => MargaritaFormValidator<number> =
-  (errorMessage = 'Value is too high!') =>
-  ({ value, params: maxValue }) => {
+  (defaultErrorMessage = 'Value is too high!') =>
+  ({ value, params: maxValue, errorMessage = defaultErrorMessage }) => {
     if (invalids.includes(maxValue)) return { valid: true };
     if (invalids.includes(value)) return { valid: true };
     const valueIsInvalid = compare(value, (number) => number > maxValue);

--- a/libs/margarita-form/src/lib/validators/number-validator.ts
+++ b/libs/margarita-form/src/lib/validators/number-validator.ts
@@ -1,8 +1,8 @@
 import { MargaritaFormValidator } from '../margarita-form-types';
 
 export const numberValidator: (errorMessage?: string) => MargaritaFormValidator<boolean> =
-  (errorMessage = 'Please enter a valid number!') =>
-  ({ value, params }) => {
+  (defaultErrorMessage = 'Please enter a valid number!') =>
+  ({ value, params, errorMessage = defaultErrorMessage }) => {
     const invalidValues: unknown[] = [null, undefined, ''];
     if (!params || invalidValues.includes(value)) return { valid: true };
     const regex = new RegExp(/\d+/g);

--- a/libs/margarita-form/src/lib/validators/pattern-validator.ts
+++ b/libs/margarita-form/src/lib/validators/pattern-validator.ts
@@ -1,8 +1,8 @@
 import { MargaritaFormValidator } from '../margarita-form-types';
 
 export const patternValidator: (errorMessage?: string) => MargaritaFormValidator<string | RegExp> =
-  (errorMessage = 'Value does not match required pattern!') =>
-  ({ value, params }) => {
+  (defaultErrorMessage = 'Value does not match required pattern!') =>
+  ({ value, params, errorMessage = defaultErrorMessage }) => {
     if (!params || !value) return { valid: true };
     const regex = new RegExp(params);
     const stringValue = typeof value === 'string' ? value : JSON.stringify(value);

--- a/libs/margarita-form/src/lib/validators/phone-validator.ts
+++ b/libs/margarita-form/src/lib/validators/phone-validator.ts
@@ -1,8 +1,8 @@
 import { MargaritaFormValidator } from '../margarita-form-types';
 
 export const phoneValidator: (errorMessage?: string) => MargaritaFormValidator<boolean> =
-  (errorMessage = 'Value must be a valid phone number!') =>
-  ({ value, params }) => {
+  (defaultErrorMessage = 'Value must be a valid phone number!') =>
+  ({ value, params, errorMessage = defaultErrorMessage }) => {
     if (!params || !value) return { valid: true };
     const regex = new RegExp(/\+?[0-9\s]{3,30}/gi);
     const stringValue = typeof value === 'string' ? value : String(value);

--- a/libs/margarita-form/src/lib/validators/required-validator.ts
+++ b/libs/margarita-form/src/lib/validators/required-validator.ts
@@ -1,8 +1,8 @@
 import { MargaritaFormValidator } from '../margarita-form-types';
 
 export const requiredValidator: (errorMessage?: string) => MargaritaFormValidator<boolean> =
-  (errorMessage = 'This field is required!') =>
-  ({ value, params }) => {
+  (defaultErrorMessage = 'This field is required!') =>
+  ({ value, params = true, errorMessage = defaultErrorMessage }) => {
     if (!params) return { valid: true };
     const invalidValues: unknown[] = [null, undefined, NaN, Infinity, ''];
     let valueIsInvalid = invalidValues.includes(value);

--- a/libs/margarita-form/src/lib/validators/same-as-validator.ts
+++ b/libs/margarita-form/src/lib/validators/same-as-validator.ts
@@ -2,8 +2,8 @@ import { combineLatest, map } from 'rxjs';
 import { MargaritaFormValidator } from '../margarita-form-types';
 
 export const sameAsValidator: (errorMessage?: string) => MargaritaFormValidator<boolean | string[]> =
-  (errorMessage = 'Please enter same value!') =>
-  ({ value, control, params }) => {
+  (defaultErrorMessage = 'Please enter same value!') =>
+  ({ value, control, params, errorMessage = defaultErrorMessage }) => {
     const parentControls = control.parent.controls;
 
     if (!params || !parentControls || !value) return { valid: true };

--- a/libs/margarita-form/src/lib/validators/slug-validator.ts
+++ b/libs/margarita-form/src/lib/validators/slug-validator.ts
@@ -1,8 +1,8 @@
 import { MargaritaFormValidator } from '../margarita-form-types';
 
 export const slugValidator: (errorMessage?: string) => MargaritaFormValidator<boolean> =
-  (errorMessage = 'Value must be a valid slug!') =>
-  ({ value, params }) => {
+  (defaultErrorMessage = 'Value must be a valid slug!') =>
+  ({ value, params, errorMessage = defaultErrorMessage }) => {
     if (!params || !value) return { valid: true };
     const regex = new RegExp(/\/?[^\s]/gi);
     const stringValue = typeof value === 'string' ? value : String(value);

--- a/libs/margarita-form/src/lib/validators/unique-validator.ts
+++ b/libs/margarita-form/src/lib/validators/unique-validator.ts
@@ -2,8 +2,8 @@ import { combineLatest, map } from 'rxjs';
 import { MargaritaFormValidator } from '../margarita-form-types';
 
 export const uniqueValidator: (errorMessage?: string) => MargaritaFormValidator<boolean | string[]> =
-  (errorMessage = 'Please enter an unique value!') =>
-  ({ value, control, params }) => {
+  (defaultErrorMessage = 'Please enter an unique value!') =>
+  ({ value, control, params, errorMessage = defaultErrorMessage }) => {
     const parentControls = control.parent.controls;
 
     if (!params || !parentControls || !value) return { valid: true };

--- a/libs/margarita-form/src/lib/validators/url-validator.ts
+++ b/libs/margarita-form/src/lib/validators/url-validator.ts
@@ -1,8 +1,8 @@
 import { MargaritaFormValidator } from '../margarita-form-types';
 
 export const urlValidator: (errorMessage?: string) => MargaritaFormValidator<boolean> =
-  (errorMessage = 'Please enter a valid url!') =>
-  ({ value, params }) => {
+  (defaultErrorMessage = 'Please enter a valid url!') =>
+  ({ value, params, errorMessage = defaultErrorMessage }) => {
     if (!params || !value) return { valid: true };
     const regex = new RegExp(/https?:\/\/.+\..+/g);
     const stringValue = typeof value === 'string' ? value : String(value);


### PR DESCRIPTION
# Reuse validators or resolvers with the following syntax:

Note: for **validators** you just need to add the validator's name as the value for resolverName.

## As string
`{ "customKey": "$$resolverName:paramsString:errorMessage" }`

Note: when used as string, params need are passed as a string to the resolver / validator!

## As object
`{ "customKey": { "resolverName": "myResolverName", "params": "any params", "errorMessage": "Custom error message" } }`